### PR TITLE
Link to the newest version of the lib docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We all know Rust's trait system is Turing complete, so tell me, why aren't we ex
 
 Honestly, I was too preoccupied with the fact that I could to stop to think whether I actually should.
 
-Believe it or not, [I even wrote docs for this](https://docs.rs/trait_eval/0.1.0/trait_eval/).
+Believe it or not, [I even wrote docs for this](https://docs.rs/trait_eval/).
 
 ## Example
 


### PR DESCRIPTION
This PR changes the docs.rs link in the readme. The link now links to the newest version of the library by default. Before, it just linked to `0.1.0` which isn't even the new version (now at `0.1.3`).